### PR TITLE
Exclude py3.8 for macos because of #24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.11"]
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Attempt to close #24